### PR TITLE
Add script to fetch AWS temporary credentials via MFA

### DIFF
--- a/infra/tf/api_gateway.tf
+++ b/infra/tf/api_gateway.tf
@@ -1,0 +1,56 @@
+resource "aws_api_gateway_rest_api" "book_api" {
+  name        = var.api_name
+  description = "API for requesting books"
+}
+
+resource "aws_api_gateway_resource" "book_resource" {
+  rest_api_id = aws_api_gateway_rest_api.book_api.id
+  parent_id   = aws_api_gateway_rest_api.book_api.root_resource_id
+  path_part   = "books"
+}
+
+resource "aws_api_gateway_method" "post_book" {
+  rest_api_id   = aws_api_gateway_rest_api.book_api.id
+  resource_id   = aws_api_gateway_resource.book_resource.id
+  http_method   = "POST"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "lambda_integration" {
+  rest_api_id             = aws_api_gateway_rest_api.book_api.id
+  resource_id             = aws_api_gateway_resource.book_resource.id
+  http_method             = aws_api_gateway_method.post_book.http_method
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.producer_lambda.invoke_arn
+}
+
+resource "aws_lambda_permission" "api_gateway_invoke" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.producer_lambda.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_api_gateway_rest_api.book_api.execution_arn}/*/*"
+}
+
+resource "aws_api_gateway_deployment" "api_deployment" {
+  depends_on = [aws_api_gateway_integration.lambda_integration]
+  rest_api_id = aws_api_gateway_rest_api.book_api.id
+
+  triggers = {
+    redeployment = sha1(jsonencode([
+      aws_api_gateway_resource.book_resource.id,
+      aws_api_gateway_method.post_book.id
+    ]))
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_api_gateway_stage" "prod" {
+  deployment_id = aws_api_gateway_deployment.api_deployment.id
+  rest_api_id   = aws_api_gateway_rest_api.book_api.id
+  stage_name    = "prod"
+}

--- a/infra/tf/outputs.tf
+++ b/infra/tf/outputs.tf
@@ -1,0 +1,4 @@
+output "api_endpoint" {
+  description = "The invoke URL for the API Gateway endpoint"
+  value       = "${aws_api_gateway_stage.prod.invoke_url}${aws_api_gateway_resource.book_resource.path_part}"
+}

--- a/infra/tf/providers.tf
+++ b/infra/tf/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.aws_region
+}

--- a/infra/tf/tests/test_api_gateway.sh
+++ b/infra/tf/tests/test_api_gateway.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This script checks if the API Gateway was created correctly.
+# It should be run AFTER you have manually run 'terraform apply'.
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Fetch the API name from Terraform output.
+# The '-raw' flag gives us the clean value without quotes.
+EXPECTED_API_NAME=$(terraform output -raw api_name)
+
+echo "Verifying API Gateway with name: $EXPECTED_API_NAME"
+
+# Use the AWS CLI to query for an API Gateway with the expected name.
+# The query returns the ID of the matching API.
+API_ID=$(aws apigateway get-rest-apis --query "items[?name=='$EXPECTED_API_NAME'].id" --output text)
+
+# Check if the API_ID variable is empty.
+if [ -z "$API_ID" ]; then
+  echo "----------------------------------------"
+  echo "TEST FAILED: API Gateway not found."
+  echo "----------------------------------------"
+  exit 1
+else
+  echo "----------------------------------------"
+  echo "TEST PASSED: Found API Gateway with ID: $API_ID"
+  echo "----------------------------------------"
+fi

--- a/infra/tf/vars.tf
+++ b/infra/tf/vars.tf
@@ -1,0 +1,41 @@
+variable "aws_region" {
+  description = "The AWS region to deploy resources in."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "producer_lambda_name" {
+  description = "The name of the producer Lambda function."
+  type        = string
+  default     = "producer_lambda"
+}
+
+variable "consumer_lambda_name" {
+  description = "The name of the consumer Lambda function."
+  type        = string
+  default     = "consumer_lambda"
+}
+
+variable "dynamodb_table_name" {
+  description = "The name of the DynamoDB table."
+  type        = string
+  default     = "BookRequests"
+}
+
+variable "sqs_queue_name" {
+  description = "The name of the SQS queue."
+  type        = string
+  default     = "book-requests-queue"
+}
+
+variable "sqs_dlq_name" {
+  description = "The name of the SQS dead-letter queue."
+  type        = string
+  default     = "book-requests-dlq"
+}
+
+variable "api_name" {
+  description = "The name of the API Gateway."
+  type        = string
+  default     = "BookRequestAPI"
+}

--- a/infra/tools/get_credentials.sh
+++ b/infra/tools/get_credentials.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# The script will load configuration from a file named 'aws.env'
+# in the same directory.
+ENV_FILE="aws.env"
+
+source "$ENV_FILE"
+
+read -p "Enter your MFA token code: " TOKEN_CODE
+
+ROLE_SESSION_NAME=${ROLE_SESSION_NAME:-"PC-one"}
+DURATION_SECONDS=${DURATION_SECONDS:-3600}
+
+echo "Requesting temporary credentials..."
+
+# Execute the AWS STS Assume Role command and capture the JSON output
+JSON_OUTPUT=$(aws sts assume-role \
+    --role-arn "$ROLE_ARN" \
+    --external-id "$EXTERNAL_ID" \
+    --role-session-name "$ROLE_SESSION_NAME" \
+    --serial-number "$SERIAL_NUMBER" \
+    --duration-seconds "$DURATION_SECONDS" \
+    --token-code "$TOKEN_CODE")
+
+# Check if the AWS command was successful
+if [ $? -ne 0 ]; then
+    echo "Failed to assume role. Please check your credentials and try again."
+    exit 1
+fi
+
+# Extract credentials using jq
+ACCESS_KEY_ID=$(echo "$JSON_OUTPUT" | jq -r '.Credentials.AccessKeyId')
+SECRET_ACCESS_KEY=$(echo "$JSON_OUTPUT" | jq -r '.Credentials.SecretAccessKey')
+SESSION_TOKEN=$(echo "$JSON_OUTPUT" | jq -r '.Credentials.SessionToken')
+
+# For convenience, also export them if the script is sourced
+export AWS_ACCESS_KEY_ID="${ACCESS_KEY_ID}"
+export AWS_SECRET_ACCESS_KEY="${SECRET_ACCESS_KEY}"
+export AWS_SESSION_TOKEN="${SESSION_TOKEN}"
+export AWS_REGION="us-east-1"
+
+# Save the extracted credentials to the .env file for the container
+cat <<EOL > .env
+AWS_ACCESS_KEY_ID=${ACCESS_KEY_ID}
+AWS_SECRET_ACCESS_KEY=${SECRET_ACCESS_KEY}
+AWS_SESSION_TOKEN=${SESSION_TOKEN}
+AWS_REGION=us-east-1
+EOL
+
+echo "Credentials have been exported to your shell and saved to .env for container use."


### PR DESCRIPTION
This pull request adds a script that enables users to fetch and export AWS temporary credentials using multi-factor authentication (MFA). This simplifies the process of working with AWS services securely by programmatically obtaining temporary session tokens.
Also implements the initial api_gateway infrastructure as a code with terraform.