### PR TITLE
Remove CodeQL cron schedule from GitHub Actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,8 +16,6 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-  schedule:
-    - cron: '23 7 * * 4'
 
 jobs:
   analyze:


### PR DESCRIPTION
This pull request removes the CodeQL cron schedule configuration from the GitHub Actions workflow.

### Summary of changes
- Eliminated the predefined cron schedule for the CodeQL workflow.
  