### PR TITLE
Add API key and rate limiting to API Gateway

### DIFF
--- a/infra/tf/api_gateway.tf
+++ b/infra/tf/api_gateway.tf
@@ -1,6 +1,10 @@
 resource "aws_api_gateway_rest_api" "book_api" {
   name        = var.api_name
   description = "API for requesting books"
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
 }
 
 resource "aws_api_gateway_resource" "book_resource" {
@@ -10,10 +14,11 @@ resource "aws_api_gateway_resource" "book_resource" {
 }
 
 resource "aws_api_gateway_method" "post_book" {
-  rest_api_id   = aws_api_gateway_rest_api.book_api.id
-  resource_id   = aws_api_gateway_resource.book_resource.id
-  http_method   = "POST"
-  authorization = "NONE"
+  rest_api_id      = aws_api_gateway_rest_api.book_api.id
+  resource_id      = aws_api_gateway_resource.book_resource.id
+  http_method      = "POST"
+  authorization    = "NONE"
+  api_key_required = true
 }
 
 resource "aws_api_gateway_integration" "lambda_integration" {
@@ -53,4 +58,83 @@ resource "aws_api_gateway_stage" "prod" {
   deployment_id = aws_api_gateway_deployment.api_deployment.id
   rest_api_id   = aws_api_gateway_rest_api.book_api.id
   stage_name    = "prod"
+}
+
+resource "aws_api_gateway_api_key" "book_app_api_key" {
+  name = "${var.api_name}-key"
+}
+
+resource "aws_api_gateway_usage_plan" "book_app_usage_plan" {
+  name = "${var.api_name}-usage-plan"
+
+  api_stages {
+    api_id = aws_api_gateway_rest_api.book_api.id
+    stage  = aws_api_gateway_stage.prod.stage_name
+  }
+
+  quota_settings {
+    limit  = 100
+    period = "DAY"
+  }
+}
+
+resource "aws_api_gateway_usage_plan_key" "book_app_usage_plan_key" {
+  key_id        = aws_api_gateway_api_key.book_app_api_key.id
+  key_type      = "API_KEY"
+  usage_plan_id = aws_api_gateway_usage_plan.book_app_usage_plan.id
+}
+
+resource "aws_wafv2_web_acl" "api_waf" {
+  name        = "${var.api_name}-waf"
+  description = "Rate limiting for API Gateway by IP"
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "IPRateLimit"
+    priority = 1
+
+    action {
+      block {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit              = 10
+        aggregate_key_type = "IP"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "Book-app-blocked-by-IPRateLimit"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "Book-app-unblocked-trafic-by-IPRateLimit"
+    sampled_requests_enabled   = true
+  }
+}
+
+resource "aws_wafv2_web_acl_association" "api_waf_assoc" {
+  resource_arn = aws_api_gateway_stage.prod.arn
+  web_acl_arn  = aws_wafv2_web_acl.api_waf.arn
+}
+
+resource "aws_ssm_parameter" "api_key" {
+  name        = "/book-app/${var.api_name}/api-key"
+  description = "API Key for ${var.api_name}"
+  type        = "SecureString"
+  value       = aws_api_gateway_api_key.book_app_api_key.value
+
+  tags = {
+    Environment = "prod"
+    Application = var.api_name
+  }
 }

--- a/infra/tf/outputs.tf
+++ b/infra/tf/outputs.tf
@@ -2,3 +2,8 @@ output "api_endpoint" {
   description = "The invoke URL for the API Gateway endpoint"
   value       = "${aws_api_gateway_stage.prod.invoke_url}/${aws_api_gateway_resource.book_resource.path_part}"
 }
+
+output "api_key_ssm_parameter_name" {
+  description = "The SSM Parameter name where the API key is stored"
+  value       = aws_ssm_parameter.api_key.name
+}


### PR DESCRIPTION
```
### Summary

This pull request enhances the API Gateway with additional security and configuration features:

- Switches API Gateway endpoint configuration to `REGIONAL`.
- Enforces API key usage for the `book POST` method.
- Introduces an API key and usage plan with a daily request quota.
- Configures a WAFv2 Web ACL for IP-based rate limiting, linked to the API stage.
- Secures the API key by storing it as a SecureString in SSM Parameter Store.
- Adds an output for the SSM Parameter name containing the API key.

### Checklist

- [ ] Documentation updated as necessary.
- [ ] Unit tests added/updated for new functionality.
- [ ] Integration tests run and verified where applicable.

```